### PR TITLE
Remove deprecated charset

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "allowUnreachableCode": true,
     "allowUnusedLabels": true,
     "alwaysStrict": true,
-    "charset": "utf8",
     "emitDecoratorMetadata": false,
     "esModuleInterop": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Looks like [charset has been deprecated](https://github.com/microsoft/TypeScript/issues/51909). It throws an error `error TS5101: Option 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.`